### PR TITLE
Small fixes to WAVLNode

### DIFF
--- a/WAVLTree/src/WAVLTree.java
+++ b/WAVLTree/src/WAVLTree.java
@@ -763,6 +763,9 @@ public class WAVLTree {
 		 * @return the size of the subtree that has this as its root, including this.
 		 */
 		public int getSubtreeSize() {
+			if (rank == OUTER_NODE_RANK) {
+				return 0;
+			}
 			int lsize = 0;
 			int rsize = 0;
 			if (left != null) {
@@ -772,6 +775,13 @@ public class WAVLTree {
 				rsize = right.size;
 			}
 			return rsize + lsize + 1; //
+		}
+		/**
+		 * updates the Node's subtree size in-place.
+		 * Should be used after changes to the tree (insert, delete, rebalance).
+		 */
+		public void updateSubtreeSize() {
+			size = getSubtreeSize();
 		}
 	}
 

--- a/WAVLTree/src/WAVLTree.java
+++ b/WAVLTree/src/WAVLTree.java
@@ -689,7 +689,7 @@ public class WAVLTree {
 		}
 
 		public WAVLNode(int key, String value) {
-			this(key, value, null, null, null, 1);
+			this(key, value, null, null, null, 0);
 		}
 
 		/**

--- a/WAVLTree/src/WAVLTree.java
+++ b/WAVLTree/src/WAVLTree.java
@@ -687,9 +687,28 @@ public class WAVLTree {
 			this.rank = rank;
 			this.size = this.getSubtreeSize();
 		}
+		/**
+		 * constructor for building a WAVLNode item with only key and value
+		 * DEPRECATED: should use constructor with left and right children 
+		 * (so we can use OUTER_NODE for left and right)
+		 * @param key 
+		 * @param value 
+		 */
 
 		public WAVLNode(int key, String value) {
 			this(key, value, null, null, null, 0);
+		}
+		/**
+		 * The constructor for adding with left and right children and parent. 
+		 * Use this constructor for adding a leaf to the tree.
+		 * @param parent the parent of the added leaf (insertion point)
+		 * @param key node's key
+		 * @param value node's value (info)
+		 * @param right should be OUTER_NODE when adding a leaf
+		 * @param left should be OUTER_NODE when adding a leaf
+		 */
+		public WAVLNode(int key, String value, WAVLNode parent, WAVLNode right, WAVLNode left) {
+			this(key, value, parent, right, left, 0);
 		}
 
 		/**

--- a/WAVLTree/src/WAVLTree.java
+++ b/WAVLTree/src/WAVLTree.java
@@ -774,7 +774,7 @@ public class WAVLTree {
 			if (right != null) {
 				rsize = right.size;
 			}
-			return rsize + lsize + 1; //
+			return rsize + lsize + 1; 
 		}
 		/**
 		 * updates the Node's subtree size in-place.


### PR DESCRIPTION
Hey, a few changes:

1. I implemented a new constructor for use in adding a leaf, with the signature:
`public WAVLNode(int key, String value, WAVLNode parent, WAVLNode right, WAVLNode left)`. This should be the constructor used for inserting leaves as it allows you to easily set its children as OUTER_NODES, and its parent as the insertion point node in the tree.

2. Added the `updateSubtreeSize()` method that needs to be called after all changes to the tree so the `size` field in the WAVLNode is maintained. I will add calls to it where necessary.
